### PR TITLE
Realistic get ip method - faster locks

### DIFF
--- a/reqlimit.go
+++ b/reqlimit.go
@@ -3,15 +3,16 @@ package reqlimit
 import (
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
 
 // limiter is a http.Handler that rate-limits a http.Handler on a per-IP basis.
 type limiter struct {
-	mu sync.Mutex
+	mu       sync.RWMutex // locks for requests
+	requests map[string](chan struct{})
 
-	requests     map[string](chan struct{})
 	limitTimeout time.Duration
 	limit        uint64
 
@@ -30,26 +31,55 @@ func New(h http.Handler, limit uint64, timeout time.Duration) *limiter {
 	}
 }
 
+// getIP tries to find the real ip address of a client.
+func getIP(r *http.Request) (string, error) {
+	header := r.Header.Get("X-Real-Ip")
+	realIP := strings.TrimSpace(header)
+	if realIP != "" {
+		return realIP, nil
+	}
+
+	realIP = r.Header.Get("X-Forwarded-For")
+	idx := strings.IndexByte(realIP, ',')
+	if idx >= 0 {
+		realIP = realIP[0:idx]
+	}
+	realIP = strings.TrimSpace(realIP)
+	if realIP != "" {
+		return realIP, nil
+	}
+
+	addr := strings.TrimSpace(r.RemoteAddr)
+
+	// if addr has port use the net.SplitHostPort otherwise(error occurs) take as it is
+	ip, _, err := net.SplitHostPort(addr)
+	return ip, err
+}
+
 // Listener's ServeHTTP implements the http.Handler interface and checks if the
 // remote host has exceeded the request limit. If it has, it returns a
 // http.Error with http.StatusTooManyRequests. Otherwise, the protected handler
 // will be called.
 func (l *limiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
+	remoteIP, err := getIP(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// grab the requests channel for this remote host, or create it if it doesn't
-	// exist
-	l.mu.Lock()
+	// grab the requests channel for this remote host
+	l.mu.RLock() // read lock
 	requests, exists := l.requests[remoteIP]
+	l.mu.RUnlock()
+
+	// or create it if it doesn't exist
 	if !exists {
 		requests = make(chan struct{}, l.limit)
+
+		l.mu.Lock() // write & read lock
 		l.requests[remoteIP] = requests
+		l.mu.Unlock()
 	}
-	l.mu.Unlock()
 
 	// add to the request channel, throw an error if it is currently full.
 	select {


### PR DESCRIPTION
Hello @johnathanhowell and welcome to Go.

Locks in go are performing better on small code-blocks than wrapped to a bigger one. 
At these changes, 

- I changed the `sync.Mutex` to `sync.RWMutex` in order to lock/unlock per-read or read & write when ever we need it.
- I also introduced a more realistic method  to get an IP, even behind a regular proxy.
- I commented the `mu` variable in order to be easy to understand what it locks/unlocks (it's a good practice to comment the lockers following by the variable(s) )