### PR TITLE
Use counter + time.AfterFunc instead of goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ func main() {
 A limited handler is a bit slower and requires a bit more memory than a naked handler. Here's the benchmarks:
 
 ```
-BenchmarkLimitedHandler-8        1000000              1703 ns/op            1488 B/op         14 allocs/op
-BenchmarkHandler-8               3000000               504 ns/op             656 B/op          6 allocs/op
+BenchmarkLimitedHandlerSingleIP-4    5000000       383 ns/op     120 B/op       3 allocs/op
+BenchmarkLimitedHandlerManyIPs-4     2000000       532 ns/op     203 B/op       2 allocs/op
+BenchmarkRawHandler-4              100000000      13.3 ns/op       0 B/op       0 allocs/op
 ```
 

--- a/reqlimit.go
+++ b/reqlimit.go
@@ -55,10 +55,7 @@ func (l *limiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	select {
 	case requests <- struct{}{}:
 		// drain the request channel after the limit timeout
-		go func() {
-			time.Sleep(l.limitTimeout)
-			<-requests
-		}()
+		time.AfterFunc(l.limitTimeout, func() { <-requests })
 
 	default:
 		http.Error(w, "request limit exceeded", http.StatusTooManyRequests)


### PR DESCRIPTION
`time.AfterFunc` handles all timers in a single goroutine, so we don't need to allocate a new goroutine for every request.

Benchmark comparison:
```
// old
BenchmarkLimitedHandlerSingleIP-4   	3000000      399 ns/op    108 B/op      2 allocs/op
BenchmarkLimitedHandlerManyIPs-4    	1000000     2438 ns/op    831 B/op      3 allocs/op

// new
BenchmarkLimitedHandlerSingleIP-4   	5000000      395 ns/op    121 B/op      2 allocs/op
BenchmarkLimitedHandlerManyIPs-4    	2000000      520 ns/op    203 B/op      2 allocs/op
```
The effect is more pronounced when there are many concurrent requests and the timeout is long.

More important is the fact that the new implementation will clean up map entries that hit 0, whereas the channel-based implementation grows unbounded.

I also changed the benchmarks to mutate a single request object instead of allocating a new one in the loop body, which was severely distorting the results.